### PR TITLE
Fix GetLatestOpenEpoch with appID required

### DIFF
--- a/pkg/repository/epoch_repository.go
+++ b/pkg/repository/epoch_repository.go
@@ -17,14 +17,13 @@ func NewEpochRepository(db *sqlx.DB) *EpochRepository {
 	return &EpochRepository{db}
 }
 
-func (e *EpochRepository) GetLatestOpenEpoch(ctx context.Context) (*model.Epoch, error) {
-	query := `SELECT application_id, index, first_block, last_block, claim_hash,
-                    claim_transaction_hash, status, virtual_index, created_at, updated_at
+func (e *EpochRepository) GetLatestOpenEpochByAppID(ctx context.Context, appID int64) (*model.Epoch, error) {
+	query := `SELECT *
 	FROM epoch
-	WHERE status = $1
+	WHERE status = $1 AND application_id = $2
 	ORDER BY index DESC
 	LIMIT 1`
-	args := []any{model.EpochStatus_Open}
+	args := []any{model.EpochStatus_Open, appID}
 
 	epoch := model.Epoch{}
 
@@ -46,8 +45,7 @@ func (e *EpochRepository) GetLatestOpenEpoch(ctx context.Context) (*model.Epoch,
 
 // FindOne retrieves a specific epoch by its index
 func (e *EpochRepository) FindOne(ctx context.Context, index uint64) (*model.Epoch, error) {
-	query := `SELECT application_id, index, first_block, last_block, claim_hash,
-                    claim_transaction_hash, status, virtual_index, created_at, updated_at
+	query := `SELECT *
 	          FROM epoch
 	          WHERE index = $1`
 	args := []any{index}
@@ -72,4 +70,3 @@ func (e *EpochRepository) FindOne(ctx context.Context, index uint64) (*model.Epo
 
 	return &epoch, nil
 }
-

--- a/pkg/repository/epoch_repository.go
+++ b/pkg/repository/epoch_repository.go
@@ -18,7 +18,16 @@ func NewEpochRepository(db *sqlx.DB) *EpochRepository {
 }
 
 func (e *EpochRepository) GetLatestOpenEpochByAppID(ctx context.Context, appID int64) (*model.Epoch, error) {
-	query := `SELECT *
+	query := `SELECT
+		index,
+		first_block,
+		last_block,
+		claim_hash,
+		claim_transaction_hash,
+		status,
+		virtual_index,
+		created_at,
+		updated_at
 	FROM epoch
 	WHERE status = $1 AND application_id = $2
 	ORDER BY index DESC
@@ -45,9 +54,18 @@ func (e *EpochRepository) GetLatestOpenEpochByAppID(ctx context.Context, appID i
 
 // FindOne retrieves a specific epoch by its index
 func (e *EpochRepository) FindOne(ctx context.Context, index uint64) (*model.Epoch, error) {
-	query := `SELECT *
-	          FROM epoch
-	          WHERE index = $1`
+	query := `SELECT
+		index,
+		first_block,
+		last_block,
+		claim_hash,
+		claim_transaction_hash,
+		status,
+		virtual_index,
+		created_at,
+		updated_at
+	FROM epoch
+	WHERE index = $1`
 	args := []any{index}
 
 	epoch := model.Epoch{}

--- a/pkg/repository/epoch_repository_test.go
+++ b/pkg/repository/epoch_repository_test.go
@@ -92,7 +92,7 @@ func (s *EpochRepositorySuite) TestGetLatestOpenEpochWrongByAppID() {
 	s.Error(err)
 }
 
-func (s *EpochRepositorySuite) TestGetLatestOpenEpochByAppId() {
+func (s *EpochRepositorySuite) TestGetLatestOpenEpochByAppID() {
 	ctx, ctxCancel := context.WithCancel(s.ctx)
 	defer ctxCancel()
 

--- a/pkg/repository/epoch_repository_test.go
+++ b/pkg/repository/epoch_repository_test.go
@@ -24,7 +24,7 @@ type EpochRepositorySuite struct {
 	ctx             context.Context
 	ctxCancel       context.CancelFunc
 	image           *postgres.PostgresContainer
-	schemaPath       string
+	schemaPath      string
 }
 
 func TestEpochRepository(t *testing.T) {
@@ -81,11 +81,22 @@ func (s *EpochRepositorySuite) TearDownTest() {
 	s.ctxCancel()
 }
 
-func (s *EpochRepositorySuite) TestGetLatestOpenEpoch() {
+func (s *EpochRepositorySuite) TestGetLatestOpenEpochWrongByAppId() {
+	ctx, ctxCancel := context.WithCancel(s.ctx)
+	defer ctxCancel()
+	appID := int64(13)
+	_, err := s.epochRepository.GetLatestOpenEpochByAppID(ctx, appID)
+	s.Error(err)
+}
+
+
+func (s *EpochRepositorySuite) TestGetLatestOpenEpochByAppId() {
 	ctx, ctxCancel := context.WithCancel(s.ctx)
 	defer ctxCancel()
 
-	epoch, err := s.epochRepository.GetLatestOpenEpoch(ctx)
+	appID := int64(1)
+
+	epoch, err := s.epochRepository.GetLatestOpenEpochByAppID(ctx, appID)
 	s.NoError(err)
 	s.NotNil(epoch)
 	s.Equal(19, int(epoch.Index))


### PR DESCRIPTION
Rename the function to better reflect its purpose and update the tests accordingly. This change enhances clarity and ensures that the function retrieves the latest open epoch by application ID.