### PR TITLE
ci: Update output variable handling in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,4 +74,4 @@ jobs:
           git fetch --tag
           TAG_NAME=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "tag_name=${TAG_NAME}" >> $GITHUB_ENV
-          echo "::set-output name=tag_name::${TAG_NAME}"
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replace deprecated `set-output` command with the new method for setting output variables in GitHub Actions. This change improves compatibility with the latest GitHub Actions features.

Warning message:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```